### PR TITLE
warningsでCIが落ちないように修正

### DIFF
--- a/.github/workflows/rust_format.yaml
+++ b/.github/workflows/rust_format.yaml
@@ -10,7 +10,7 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
-  RUSTFLAGS: "-Dwarnings"
+  RUSTFLAGS: "-Dwarnings -Dwarnings=warnings"
 
 jobs:
   test:

--- a/.github/workflows/rust_format.yaml
+++ b/.github/workflows/rust_format.yaml
@@ -10,7 +10,7 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
-  RUSTFLAGS: "-Dwarnings -Dwarnings=warnings"
+  RUSTFLAGS: "-Dwarnings"
 
 jobs:
   test:

--- a/.github/workflows/rust_format.yaml
+++ b/.github/workflows/rust_format.yaml
@@ -10,7 +10,6 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
-  RUSTFLAGS: "-D warnings"
 
 jobs:
   test:

--- a/.github/workflows/rust_format.yaml
+++ b/.github/workflows/rust_format.yaml
@@ -10,7 +10,7 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
-  RUSTFLAGS: "-Dwarnings"
+  RUSTFLAGS: "-D warnings"
 
 jobs:
   test:

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,3 @@
 fn main() {
-    println!("Hello, world!");
+    let test = String::from("waiwai");
 }


### PR DESCRIPTION
## 課題
手元で下記のようなwarningsが、CI上ではエラーとなって落ちる
```bash
kanoda@nodakazushinoMacBook-Air rust-data-pipeline % cargo run
   Compiling rust-data-pipeline v0.1.0 (/Users/kanoda/Programming/rust-data-pipeline)
warning: unused variable: `test`
 --> src/main.rs:2:9
  |
2 |     let test = String::from("waiwai");
  |         ^^^^ help: if this is intentional, prefix it with an underscore: `_test`
  |
  = note: `#[warn(unused_variables)]` on by default

warning: `rust-data-pipeline` (bin "rust-data-pipeline") generated 1 warning (run `cargo fix --bin "rust-data-pipeline"` to apply 1 suggestion)
    Finished dev [unoptimized + debuginfo] target(s) in 0.41s
     Running `target/debug/rust-data-pipeline`
```

## 修正点
```yaml
  RUSTFLAGS: "-Dwarnings"
```
を消した
テスト用に
```rust
let test = String::from("waiwai");
```
を流して確認(CIが通った)